### PR TITLE
refactor(ops/exec): Enable calling functions with no input/output

### DIFF
--- a/tests/test_exec.py
+++ b/tests/test_exec.py
@@ -23,7 +23,7 @@ def test_args() -> bytes:
     }
 
 
-def test_exec_genop(test_lib, test_args):
+def test_exec(test_lib, test_args):
     session = Session()
     res = session.exec(
         test_lib["path"],
@@ -34,6 +34,15 @@ def test_exec_genop(test_lib, test_args):
     assert res == test_args["read"]
 
 
+def test_exec_no_args(test_lib):
+    session = Session()
+    res = session.exec(
+        test_lib["path"],
+        test_lib["symbol"],
+    )
+    assert res is None
+
+
 def test_exec_with_res(test_lib, test_args):
     session = Session()
     lib = Resource(test_lib["path"], ResourceType.LIB)
@@ -42,3 +51,11 @@ def test_exec_with_res(test_lib, test_args):
         lib, test_lib["symbol"], test_args["read"], test_args["write"]
     )
     assert res == test_args["read"]
+
+
+def test_exec_with_res_no_args(test_lib):
+    session = Session()
+    lib = Resource(test_lib["path"], ResourceType.LIB)
+    lib.register(session)
+    res = session.exec_with_resource(lib, test_lib["symbol"])
+    assert res is None


### PR DESCRIPTION
Enable using `exec` and `exec_with_resource` methods with no input or output arguments for the called function